### PR TITLE
Support optional hex value as a `color` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Crypto Icons API
 
-This project builds ontop of the amazing [Cryptocurrency Icons](https://github.com/atomiclabs/cryptocurrency-icons) project.
+This project is a service for serving the icons created and maintained by the
+[Cryptocurrency Icons](https://github.com/atomiclabs/cryptocurrency-icons) project.
 
-Rather than bundling all the images into our app, [Quids](http://quidsapp.com), and having to ship an update everytime a new currency was added we built this service.
+The service was originally built for use in [Quids for Mac](http://quidsapp.com)
+to avoid bundling every icon with the client. Instead, we use this service to
+dynamically accept the SVG source and render a PNG, using any of the included
+icon styles provided.
+
+You are welcome to fork this GitHub repo and deploy your own version of the
+service. You can even deploy this straight to Heroku.
 
 ## API
 
@@ -17,6 +24,16 @@ GET https://cryptoicons.org/api/:style/:currency/:size
 - `color`
 - `icon`
 
+### Override Colors
+
+By default both `color` and `icon` styles have a color assigned from the original
+assets created by the
+[Cryptocurrency Icons](https://github.com/atomiclabs/cryptocurrency-icons) project.
+
+You can optionally override these colors by passing your own hexidecimal value
+as the last value to API calls for these styles only. The hexidecimal value
+you pass should not include the `#` prefix.
+
 ### Examples
 
 ```
@@ -27,12 +44,15 @@ GET https://cryptoicons.org/api/color/eth/600
 GET https://cryptoicons.org/api/black/btc/200
 ```
 
-## Deploy To Heroku
+```
+GET https://cryptoicons.org/api/icon/btc/ff00ff
+```
 
+## Deploy to Heroku
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## License
 
-All the .svg files are under the same license as the [Cryptocurrency Icons](https://github.com/atomiclabs/cryptocurrency-icons) project.
+All the SVG files are under the same license as the [Cryptocurrency Icons](https://github.com/atomiclabs/cryptocurrency-icons) project.
 
 The rest of the project is MIT.

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "addons": ["heroku-redis:hobby-dev"],
   "buildpacks": [
     {
-      "url": "heroku/nodejs",
+      "url": "urn:buildpack:heroku/nodejs",
       "url": "https://github.com/jontewks/puppeteer-heroku-buildpack.git"
     }
   ]

--- a/public/index.html
+++ b/public/index.html
@@ -79,17 +79,44 @@
       </li>
     </ol>
 
+    <h3>Color overrides</h3>
+
+    <p>
+      To override the color of <code class="inline">color</code> and
+      <code class="inline">icon</code> icons, an additional optional parameter
+      can be passed, any valid hexidecimal string such as
+      <code class="inline">ff00ff</code>.
+    </p>
+
+    <p>
+      <code contenteditable>
+      GET https://cryptoicons.org/api/:style/:currency/:size/:color
+      </code>
+    </p>
+
     <h3>Examples</h3>
 
     <p>
       <code contenteditable>
-      GET https://cryptoicons.org/api/color/eth/600
+      GET https://cryptoicons.org/api/icon/eth/200
       </code>
     </p>
 
     <p>
       <code contenteditable>
-      GET https://cryptoicons.org/api/black/btc/200
+      GET https://cryptoicons.org/api/white/btc/200
+      </code>
+    </p>
+
+    <p>
+      <code contenteditable>
+      GET https://cryptoicons.org/api/black/bth/400
+      </code>
+    </p>
+
+    <p>
+      <code contenteditable>
+      GET https://cryptoicons.org/api/color/ltc/600/ff00ff
       </code>
     </p>
   </section>

--- a/public/main.css
+++ b/public/main.css
@@ -63,6 +63,12 @@ code {
   font-family: "SFMono-Regular", monospace;
 }
 
+code.inline {
+  background: #efefef;
+  border-radius: 10px;
+  margin: 0 5px;
+}
+
 p code {
   position: relative;
   display: inline-block;

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ app.get('/', function(req, res) {
 })
 
 // GET png
-app.get('/api/:style/:currency/:size', async(req, res) => {
+app.get('/api/:style/:currency/:size/:color?', async(req, res) => {
   // Params
   const style = req.params.style
   const currency = req.params.currency
@@ -80,6 +80,7 @@ async function generatePNG(req, res, redis) {
   const style = req.params.style
   const currency = req.params.currency
   const size = req.params.size
+  const color = req.params.color
   const cacheKey = req.path
   const filename = currency + '-' + style + '-' + size + '.png'
     
@@ -99,6 +100,10 @@ async function generatePNG(req, res, redis) {
 
   const svgElement = element.getElementsByTagName("svg")[0]
 
+  // Define the circles
+  const colorCircle = element.getElementsByTagName("circle")[0]
+  const iconCircle = element.getElementsByTagName("use")[1]
+
   // Set viewBox so SVG resizes correctly
   const originalSize = svgElement.getAttribute('width')
   svgElement.setAttribute('viewBox', '0 0 ' + originalSize + ' ' + originalSize)
@@ -106,6 +111,15 @@ async function generatePNG(req, res, redis) {
   // Set requested size
   svgElement.setAttribute('width', size)
   svgElement.setAttribute('height', size)
+
+  // Set circle color, if `color` or `icon`
+  if (color != null && style == 'color') {
+    const colorString = '#' + color
+    colorCircle.setAttribute('fill', colorString)
+  } else if (color != null && style == 'icon') {
+    const colorString = '#' + color
+    iconCircle.setAttribute('fill', colorString)
+  }
 
   // Convert to PNG
   const png = await convert(element.innerHTML, {


### PR DESCRIPTION
You can now provide a hex value as an optional last parameter to the API calls for `color` and `icon` styles. For `color` icons it's a straight color swap, in the case of `icon` icons, the gradient blend on top of the color swap will be preserved correctly.

eg. `/api/color/eth/300/ff00ff`

That will return the icon with a pink background.

![eth-color-300](https://user-images.githubusercontent.com/717867/45254281-bc7e4880-b36d-11e8-9936-929a1fda94fe.png)

Or `/api/icon/eth/300/ff00ff`

![eth-icon-300](https://user-images.githubusercontent.com/717867/45254286-d881ea00-b36d-11e8-9fd4-18b21e759ac6.png)


